### PR TITLE
Switch to Github Actions & add downloadable distribution

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,31 @@
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: Build Plugin
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: ./gradlew buildPlugin
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        name: plugin-zip
+        path: build/distributions/intellij-gdscript.zip

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -24,8 +24,13 @@ jobs:
       run: chmod +x gradlew
     - name: Build with Gradle
       run: ./gradlew buildPlugin
+    - name: Unzip the distributions before upload
+      uses: DuckSoft/extract-7z-action@v1.0
+      with:
+        pathSource: build/distributions/intellij-gdscript.zip
+        pathTarget: build/distributions/
     - name: Upload artifact
       uses: actions/upload-artifact@v1.0.0
       with:
-        name: plugin-zip
-        path: build/distributions/intellij-gdscript.zip
+        name: intellij-gdscript
+        path: build/distributions/intellij-gdscript

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -28,9 +28,9 @@ jobs:
       uses: DuckSoft/extract-7z-action@v1.0
       with:
         pathSource: build/distributions/intellij-gdscript.zip
-        pathTarget: build/distributions/
+        pathTarget: build/distributions/unpacked
     - name: Upload artifact
       uses: actions/upload-artifact@v1.0.0
       with:
         name: intellij-gdscript
-        path: build/distributions/intellij-gdscript
+        path: build/distributions/unpacked

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: java
-
-script:
-  - ./gradlew build

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-## GDScript plugin for IntelliJ IDEA [![Build Status](https://travis-ci.org/exigow/intellij-gdscript.svg?branch=master)](https://travis-ci.org/exigow/intellij-gdscript?branch=master)
+## GDScript plugin for IntelliJ IDEA [![Build Plugin](https://github.com/markusmo3/intellij-gdscript/workflows/Build%20Plugin/badge.svg)](https://github.com/markusmo3/intellij-gdscript/actions?query=workflow%3A%22Build+Plugin%22)
 
 ![Screenshot](https://i.imgur.com/WLLXkf4.png)
 
@@ -12,9 +12,9 @@
 
 ### Installation
 
-1. Run `./gradlew buildPlugin`.
+1. Download the latest build artifact from the ["Build Plugin" Github Action](https://github.com/markusmo3/intellij-gdscript/actions?query=workflow%3A%22Build+Plugin%22)
 1. Start IntelliJ, navigate to `Settings` | `Plugins` | :gear: | `Install plugin from disk...`.
-1. Find `build/distributions/intellij-gdscript.zip` and restart IDE.
+1. Find the downloaded zip file and restart IDE.
 
 Alternatively, [download](https://plugins.jetbrains.com/plugin/13107-godot-gdscript/versions) latest version from official plugins repository. Release might be outdated so it's not recommended.
 
@@ -22,6 +22,7 @@ Plugin works with **all** IntelliJ-based IDEs starting from v2019.2.
 
 ### Usage & Development
 
+* `./gradlew buildPlugin` - builds the plugin distribution to `build/distributions/intellij-gdscript.zip`
 * `./gradlew runIde` - run sandbox with installed plugin. First run may take a while.
 * `./gradlew test` - run all tests.
 * `./gradlew generateGrammarSource` - generate ANTLR lexer and parser Java class.


### PR DESCRIPTION
Hey there, so my story is the following:

I really didn't want to checkout the project and build it myself, which is why i switched the project to Github Actions and created an Action that automatically creates a Github Action Artifact for the distribution.

I know you currently use Travis and that their software can surely do the same, i just thought it would be nice to have everything on the same platform.

If you like the switch, then all the `markusmo3/intellij-gdscript` have to be changed to `exigow/intellij-gdscript` in order for this to work.
Just message me if i should do that.