### PR TITLE
Avoid suggesting plugin for IDEA 2020.1+

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -16,7 +16,7 @@
 		</ul>
 	]]>
 	</description>
-	<idea-version since-build="193.2252"/>
+	<idea-version since-build="193.2252" until-build="201.0"/>
 	<depends>com.intellij.modules.lang</depends>
 	<extensions defaultExtensionNs="com.intellij">
 		<!-- api -->


### PR DESCRIPTION
As far as I tried plugin doesn't compile with IDEA versions newer then 2019.3, so adding `until-build` would help to avoid suggestion to install the plugin.